### PR TITLE
Fix: Resolve duplicate HomePage declaration in App.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7186,7 +7186,6 @@
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.1"
       },

--- a/src/App.js
+++ b/src/App.js
@@ -275,8 +275,4 @@ function App() {
     );
 }
 
-const HomePage = ({ navigate }) => ( 
-// Removed HomePage, VehicleForm, AdminPage, VehicleDetailPage, DigitalCredential, DashboardPage components code
-// They are now in src/components/pages/
-
 export default App;


### PR DESCRIPTION
The build was failing due to a duplicate declaration of the 'HomePage' identifier in `src/App.js`. The `HomePage` component was being imported from an external file (`./components/pages/HomePage.js`) and also being declared as a functional component directly within `src/App.js`.

This commit removes the redundant functional component declaration from `src/App.js`, relying on the imported version as intended. This resolves the ESLint error "Syntax error: Identifier 'HomePage' has already been declared." and allows the build to complete successfully.