### PR TITLE
I've optimized the `useSnackbar` hook by wrapping `showSnackbar` and …

### DIFF
--- a/src/hooks/useSnackbar.js
+++ b/src/hooks/useSnackbar.js
@@ -1,18 +1,29 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react'; // Add useCallback
 
 export const useSnackbar = () => {
     const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
 
-    const showSnackbar = (message, severity = 'success') => {
+    const showSnackbar = useCallback((message, severity = 'success') => {
         setSnackbar({ open: true, message, severity });
-    };
+    }, []); // setSnackbar is stable, so empty dependency array is fine
 
-    const handleCloseSnackbar = (_, reason) => {
+    const handleCloseSnackbar = useCallback((_, reason) => {
         if (reason === 'clickaway') {
             return;
         }
-        setSnackbar({ ...snackbar, open: false });
-    };
+        // It's generally safer to use the functional update form of setState
+        // if the new state depends on the previous state, to avoid stale closures,
+        // though with useCallback's own dependency array including snackbar, it's less of an issue here.
+        // However, best practice would be:
+        // setSnackbar(prevSnackbar => ({ ...prevSnackbar, open: false }));
+        // For this specific case, directly using snackbar in the deps array of useCallback
+        // and then in the function body is also acceptable.
+        setSnackbar(prevSnackbar => ({ ...prevSnackbar, open: false }));
+    }, []); // handleCloseSnackbar depends on no external variables from the hook's scope that change
+    // If it did use `snackbar` directly like `setSnackbar({ ...snackbar, open: false });`
+    // then `snackbar` would need to be in the dependency array: `}, [snackbar]);`
+    // Given it was `setSnackbar({ ...snackbar, open: false });` before, let's use the functional update `setSnackbar(prevSnackbar => ({ ...prevSnackbar, open: false }));` which is safer and allows an empty dependency array for useCallback.
+
 
     return { snackbar, showSnackbar, handleCloseSnackbar };
 };


### PR DESCRIPTION
…`handleCloseSnackbar` in `useCallback`.

This should stabilize the references of these functions. This means that `useEffect` hooks in components that use `useSnackbar` (like `App.js`) won't re-run as often just because these functions seemed to change.

This should help with a few things:
- It should stop the Firestore listener from constantly unsubscribing and re-subscribing.
- It should get rid of those loading spinners that kept showing up because of the listener churn.
- It might also cut down on Firestore 400 errors if they were being made worse by too many connection attempts.