### PR TITLE
Fix credential download by bundling jsPDF

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.19.2",
     "firebase": "^11.8.1",
+    "jspdf": "^2.5.2",
     "lucide-react": "^0.511.0",
     "nodemailer": "^6.9.4",
     "react": "^19.1.0",
@@ -52,8 +53,8 @@
   "devDependencies": {
     "autoprefixer": "^10.4.19",
     "cross-env": "^7.0.3",
-    "react-scripts": "^5.0.1",
     "postcss": "^8.4.38",
+    "react-scripts": "^5.0.1",
     "tailwindcss": "^3.4.3"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">

--- a/src/App.js
+++ b/src/App.js
@@ -69,6 +69,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 
 // Recharts
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
+import { jsPDF } from 'jspdf';
 
 const LOGO_SAN_ISIDRO_URL = "https://www.sanisidro.gob.ar/sites/default/files/logo_san_isidro_horizontal_blanco_web_1.png"; 
 
@@ -951,13 +952,14 @@ const DigitalCredential = ({ vehicle, navigate, showSnackbar }) => {
     };
 
     const createPDF = () => {
-        if (!window.jspdf || !window.jspdf.jsPDF) {
-            console.error("jsPDF no está cargado globalmente.");
-            showSnackbar("Error al generar PDF: la librería jsPDF no está disponible.", "error");
+        let pdf;
+        try {
+            pdf = new jsPDF('p', 'pt', 'a4');
+        } catch (e) {
+            console.error('jsPDF error:', e);
+            showSnackbar('Error al generar PDF.', 'error');
             return null;
         }
-        const { jsPDF } = window.jspdf;
-        const pdf = new jsPDF('p', 'pt', 'a4');
         
         const primaryColor = theme.palette.primary.dark; 
         const textColor = '#333333';


### PR DESCRIPTION
## Summary
- include `jspdf` as a dependency
- remove external jsPDF script tag
- import jsPDF module and handle PDF creation errors

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_6842bfbbe05c832683768afbc577e7e5