### PR TITLE
Add photo capture and vehicle edit feature

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,8 @@ import {
     fetchAllVehicles as fetchAllVehiclesService,
     handleRegisterVehicle as registerVehicleService,
     handleSelectVehicleForDetail as selectVehicleForDetailService,
-    handleAddDisinfection as addDisinfectionService
+    handleAddDisinfection as addDisinfectionService,
+    handleUpdateVehicle as updateVehicleService
     // uploadFileToStorage is used by addDisinfectionService, not directly here
 } from './services/firestoreService';
 
@@ -283,6 +284,21 @@ function App() {
         }
         setLoading(false);
     };
+
+    const handleUpdateVehicle = async (vehicleId, data) => {
+        if (!currentUser) { showSnackbar("Debe estar autenticado.", "error"); return; }
+        setLoading(true);
+        try {
+            const updated = await updateVehicleService(vehiclesCollectionPath, vehicleId, data);
+            setSelectedVehicleForApp(updated);
+            showSnackbar("Vehículo actualizado.", "success");
+            setCurrentPage('vehicleDetail');
+        } catch (e) {
+            console.error("Update Vehicle Error: ", e);
+            showSnackbar(e.message || "Error al actualizar vehículo.", "error");
+        }
+        setLoading(false);
+    };
     
     const navigate = (page, vehicleData = null) => {
         if (vehicleData) setSelectedVehicleForApp(vehicleData);
@@ -331,6 +347,15 @@ function App() {
                     )}
                     {currentPage === 'home' && <HomePage navigate={navigate} />}
                     {currentPage === 'register' && <VehicleForm onSubmit={handleRegisterVehicle} navigate={navigate} showSnackbar={showSnackbar} />}
+                    {currentPage === 'editVehicle' && selectedVehicleForApp && (
+                        <VehicleForm
+                            onSubmit={(data) => handleUpdateVehicle(selectedVehicleForApp.id, data)}
+                            navigate={navigate}
+                            showSnackbar={showSnackbar}
+                            initialData={selectedVehicleForApp}
+                            editMode
+                        />
+                    )}
                     {currentPage === 'admin' && <AdminPage searchTerm={searchTerm} setSearchTerm={setSearchTerm} handleSearch={handleSearchVehicle} searchResults={searchResults} handleSelectVehicle={handleSelectVehicleForDetail} navigate={navigate} valorMetroCubico={valorMetroCubico} onUpdateValorMetroCubico={handleUpdateValorMetroCubico} />}
                     {currentPage === 'dashboard' && <DashboardPage vehicles={allVehiclesForDashboard} />}
                     {currentPage === 'vehicleDetail' && selectedVehicleForApp && <VehicleDetailPage vehicle={selectedVehicleForApp} onAddDisinfection={handleAddDisinfection} navigate={navigate} showSnackbar={showSnackbar} onOpenPaymentPage={() => setOpenPaymentModal(true)} valorMetroCubico={valorMetroCubico} setGeminiLoading={setGeminiLoading} />}

--- a/src/components/pages/VehicleDetailPage.js
+++ b/src/components/pages/VehicleDetailPage.js
@@ -7,6 +7,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import AddCircleIcon from '@mui/icons-material/AddCircleOutline';
 import PaymentIcon from '@mui/icons-material/Payment';
 import PrintIcon from '@mui/icons-material/Print';
+import SettingsIcon from '@mui/icons-material/Settings';
 import ArticleIcon from '@mui/icons-material/Article';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
@@ -183,8 +184,11 @@ const VehicleDetailPage = ({ vehicle, onAddDisinfection, navigate, showSnackbar,
                 <Button variant="outlined" color="primary" startIcon={<PaymentIcon />} onClick={onOpenPaymentPage}>
                     Generar Boleta de Pago
                 </Button>
-                 <Button variant="outlined" startIcon={<PrintIcon />} onClick={() => navigate('credential', vehicle)}>
+                <Button variant="outlined" startIcon={<PrintIcon />} onClick={() => navigate('credential', vehicle)}>
                     Ver Credencial
+                </Button>
+                <Button variant="outlined" color="warning" startIcon={<SettingsIcon />} onClick={() => navigate('editVehicle', vehicle)}>
+                    Editar Vehículo
                 </Button>
                 <Button variant="outlined" color="info" startIcon={<AutoAwesomeIcon />} onClick={handleGenerateHistorySummary}>
                     ✨ Resumir Historial (IA)
@@ -204,7 +208,7 @@ const VehicleDetailPage = ({ vehicle, onAddDisinfection, navigate, showSnackbar,
                         <Grid item xs={12} sm={4}>
                             <Button variant="outlined" component="label" fullWidth startIcon={<CloudUploadIcon />} sx={{mt: {xs:0, sm:1}}}>
                                 Foto Recibo
-                                <input type="file" hidden accept="image/*" onChange={(e) => handleFileChange(e, setReciboFile)} />
+                                <input type="file" hidden accept="image/*" capture="environment" onChange={(e) => handleFileChange(e, setReciboFile)} />
                             </Button>
                             {reciboFile && <Typography variant="caption" display="block" sx={{mt:0.5, textAlign:'center'}}>{reciboFile.name}</Typography>}
                         </Grid>
@@ -217,7 +221,7 @@ const VehicleDetailPage = ({ vehicle, onAddDisinfection, navigate, showSnackbar,
                         <Grid item xs={12} sm={4}>
                              <Button variant="outlined" component="label" fullWidth startIcon={<CloudUploadIcon />} sx={{mt: {xs:0, sm:1}}}>
                                 Foto Trans.
-                                <input type="file" hidden accept="image/*" onChange={(e) => handleFileChange(e, setTransaccionFile)} />
+                                <input type="file" hidden accept="image/*" capture="environment" onChange={(e) => handleFileChange(e, setTransaccionFile)} />
                             </Button>
                             {transaccionFile && <Typography variant="caption" display="block" sx={{mt:0.5, textAlign:'center'}}>{transaccionFile.name}</Typography>}
                         </Grid>

--- a/src/components/pages/VehicleForm.js
+++ b/src/components/pages/VehicleForm.js
@@ -31,7 +31,7 @@ import { StyledPaper, TIPOS_VEHICULO, theme } from '../../theme'; // Import from
 //     padding: theme.spacing(3), marginTop: theme.spacing(2), marginBottom: theme.spacing(2),
 // }));
 
-const VehicleForm = ({ onSubmit, navigate, showSnackbar, initialData = {} }) => {
+const VehicleForm = ({ onSubmit, navigate, showSnackbar, initialData = {}, editMode = false }) => {
     const [formData, setFormData] = useState({
         patente: initialData.patente || '',
         marca: initialData.marca || '',
@@ -91,8 +91,8 @@ const VehicleForm = ({ onSubmit, navigate, showSnackbar, initialData = {} }) => 
     return (
         <StyledPaper>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-                <IconButton onClick={() => navigate('home')}><ArrowBackIcon /></IconButton>
-                <Typography variant="h5" component="h2" sx={{ ml: 1, color: theme.palette.primary.dark }}>Registrar Vehículo</Typography>
+                <IconButton onClick={() => navigate(editMode ? 'vehicleDetail' : 'home')}><ArrowBackIcon /></IconButton>
+                <Typography variant="h5" component="h2" sx={{ ml: 1, color: theme.palette.primary.dark }}>{editMode ? 'Editar Vehículo' : 'Registrar Vehículo'}</Typography>
             </Box>
             <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
                 <TextField margin="normal" required fullWidth id="patente" label="Patente (Ej: AA123BB)" name="patente" value={formData.patente} onChange={handleChange} inputProps={{ maxLength: 10, style: { textTransform: 'uppercase' } }} InputProps={{ startAdornment: <ReceiptIcon sx={{mr:1, color:'action.active'}}/> }} />
@@ -132,7 +132,7 @@ const VehicleForm = ({ onSubmit, navigate, showSnackbar, initialData = {} }) => 
                         InputProps={{ startAdornment: <EmailIcon sx={{mr:1, color:'action.active'}}/> }}
                     />
                 <TextField margin="normal" fullWidth id="numeroVehiculoMunicipal" label="Número de Vehículo Municipal (Opcional)" name="numeroVehiculoMunicipal" value={formData.numeroVehiculoMunicipal} onChange={handleChange} InputProps={{ startAdornment: <DirectionsCarIcon sx={{mr:1, color:'action.active'}}/> }}/>
-                <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2, py: 1.2 }}>Registrar Vehículo</Button>
+                <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2, py: 1.2 }}>{editMode ? 'Guardar Cambios' : 'Registrar Vehículo'}</Button>
             </Box>
         </StyledPaper>
     );

--- a/src/services/firestoreService.js
+++ b/src/services/firestoreService.js
@@ -101,6 +101,17 @@ export const handleRegisterVehicle = async (vehiclesCollectionPath, vehicleData,
     return { id: docRef.id, ...dataToSave };
 };
 
+export const handleUpdateVehicle = async (vehiclesCollectionPath, vehicleId, updatedData) => {
+    const vehicleRef = doc(db, vehiclesCollectionPath, vehicleId);
+    await updateDoc(vehicleRef, {
+        ...updatedData,
+        patente: updatedData.patente.toUpperCase(),
+        metrosCubicos: parseFloat(updatedData.metrosCubicos) || 0
+    });
+    const snap = await getDoc(vehicleRef);
+    return { id: snap.id, ...snap.data() };
+};
+
 // handleSearchVehicle is a local filter, so it might stay in App.js or be moved if it involves backend search later.
 // For now, assuming it's a local filter based on allVehiclesForDashboard, it doesn't need to be in firestoreService.js
 // If it were to query Firestore directly, it would be here.


### PR DESCRIPTION
## Summary
- allow capturing photos for receipts and transactions by using `capture` attribute
- implement service and page logic to edit vehicle data
- expose Edit Vehículo button on vehicle details

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d96280748326b0e2a4a9b11eb191