### PR TITLE
Fix Admin button page reload

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -402,7 +402,7 @@ function App() {
                             <>
                                 <Button color="inherit" onClick={() => navigate('home')} title="Inicio">Inicio</Button>
                                 <Button color="inherit" onClick={() => navigate('dashboard')} startIcon={<BarChartIcon/>}>Dashboard</Button>
-                                <Button color="inherit" onClick={() => navigate('admin')} startIcon={<SettingsIcon/>}>Admin</Button>
+                                <Button type="button" color="inherit" onClick={() => navigate('admin')} startIcon={<SettingsIcon/>}>Admin</Button>
                             </>
                         )}
                         {currentUser && <Typography variant="caption" sx={{ml:2}}>ID: {currentUser.isAnonymous ? "Anónimo" : currentUser.uid.substring(0,6)}</Typography>}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders main heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Control de Desinfección Vehicular/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/components/pages/HomePage.js
+++ b/src/components/pages/HomePage.js
@@ -40,7 +40,7 @@ const HomePage = ({ navigate }) => (
                 </Button>
             </Grid>
             <Grid item xs={12} sm={6} md={4}>
-                <Button fullWidth variant="contained" color="secondary" size="large" startIcon={<SettingsIcon />} onClick={() => navigate('admin')} sx={{ py: 1.5 }}>
+                <Button type="button" fullWidth variant="contained" color="secondary" size="large" startIcon={<SettingsIcon />} onClick={() => navigate('admin')} sx={{ py: 1.5 }}>
                     Administrar
                 </Button>
             </Grid>


### PR DESCRIPTION
## Summary
- prevent form submission when clicking **Administrar** button
- avoid page reload in the header Admin button
- update App test to look for main heading

## Testing
- `npm test` *(fails: E Failed to connect to firestore.googleapis.com:443 through proxy 172.26.0.3:8080 with status 403)*

------
https://chatgpt.com/codex/tasks/task_e_684996f8a0948326ae0eb2f5fd2e6c8a