### PR TITLE
Improve credential layout

### DIFF
--- a/src/components/pages/DigitalCredential.js
+++ b/src/components/pages/DigitalCredential.js
@@ -1,14 +1,21 @@
 import React from 'react';
 import {
-    Typography, Button, Box, Paper, Grid, IconButton, List, ListItem, ListItemText,
-    Accordion, AccordionSummary, AccordionDetails, Chip as MuiChip
+    Typography,
+    Button,
+    Box,
+    Grid,
+    IconButton,
+    List,
+    ListItem,
+    ListItemText,
+    Divider,
+    Chip as MuiChip
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import DownloadIcon from '@mui/icons-material/Download';
 import DirectionsCarIcon from '@mui/icons-material/DirectionsCar';
 import VerifiedUserIcon from '@mui/icons-material/VerifiedUser';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 // import { styled, useTheme } from '@mui/material/styles'; // useTheme is used, styled for StyledPaper is imported
 import { useTheme } from '@mui/material/styles';
 import { StyledPaper, LOGO_SAN_ISIDRO_URL } from '../../theme'; // Import from theme
@@ -124,64 +131,65 @@ const DigitalCredential = ({ vehicle, navigate, showSnackbar }) => { // LOGO_SAN
                 <Typography variant="subtitle1" color="text.secondary">Municipalidad de San Isidro - Dirección de Control de Vectores</Typography>
             </Box>
 
-            <Accordion defaultExpanded sx={{mb:2, boxShadow: 'none', '&:before': {display: 'none'} }}>
-                <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{backgroundColor: theme.palette.primary.lighter+'33', borderRadius:1}}>
-                    <DirectionsCarIcon sx={{mr:1, color: theme.palette.primary.main }} /> <Typography variant="h6" sx={{ color: theme.palette.primary.dark }}>Datos del Vehículo</Typography>
-                </AccordionSummary>
-                <AccordionDetails sx={{pt:1.5}}>
-                    <Grid container spacing={1.5}>
-                        <Grid item xs={12} sm={6}><Typography component="div"><strong>Patente:</strong> <MuiChip label={vehicle.patente} size="small" color="primary" /></Typography></Grid>
-                        <Grid item xs={12} sm={6}><Typography><strong>Marca:</strong> {vehicle.marca}</Typography></Grid>
-                        <Grid item xs={12} sm={6}><Typography><strong>Tipo:</strong> {vehicle.tipoVehiculo || 'N/A'}</Typography></Grid>
-                        <Grid item xs={12} sm={6}><Typography><strong>Dimensiones:</strong> L: {vehicle.largo || 'N/A'}m, An: {vehicle.ancho || 'N/A'}m, Al: {vehicle.altura || 'N/A'}m</Typography></Grid>
-                        <Grid item xs={12} sm={6}><Typography><strong>Metros Cúbicos:</strong> {parseFloat(vehicle.metrosCubicos).toFixed(2) || 'N/A'} m³</Typography></Grid>
-                        <Grid item xs={12} sm={6}><Typography><strong>Propietario:</strong> {vehicle.propietarioNombre}</Typography></Grid>
-                        <Grid item xs={12}><Typography><strong>Nº Vehículo Municipal:</strong> {vehicle.numeroVehiculoMunicipal || 'N/A'}</Typography></Grid>
-                    </Grid>
-                </AccordionDetails>
-            </Accordion>
+            <Box sx={{mb:3}}>
+                <Box sx={{display:'flex', alignItems:'center', mb:1}}>
+                    <DirectionsCarIcon sx={{mr:1, color: theme.palette.primary.main}} />
+                    <Typography variant="h6" sx={{color: theme.palette.primary.dark}}>Datos del Vehículo</Typography>
+                </Box>
+                <Divider sx={{mb:1}} />
+                <Grid container spacing={1.5}>
+                    <Grid item xs={12} sm={6}><Typography component="div"><strong>Patente:</strong> <MuiChip label={vehicle.patente} size="small" color="primary" /></Typography></Grid>
+                    <Grid item xs={12} sm={6}><Typography><strong>Marca:</strong> {vehicle.marca}</Typography></Grid>
+                    <Grid item xs={12} sm={6}><Typography><strong>Tipo:</strong> {vehicle.tipoVehiculo || 'N/A'}</Typography></Grid>
+                    <Grid item xs={12} sm={6}><Typography><strong>Dimensiones:</strong> L: {vehicle.largo || 'N/A'}m, An: {vehicle.ancho || 'N/A'}m, Al: {vehicle.altura || 'N/A'}m</Typography></Grid>
+                    <Grid item xs={12} sm={6}><Typography><strong>Metros Cúbicos:</strong> {parseFloat(vehicle.metrosCubicos).toFixed(2) || 'N/A'} m³</Typography></Grid>
+                    <Grid item xs={12} sm={6}><Typography><strong>Propietario:</strong> {vehicle.propietarioNombre}</Typography></Grid>
+                    <Grid item xs={12}><Typography><strong>Nº Vehículo Municipal:</strong> {vehicle.numeroVehiculoMunicipal || 'N/A'}</Typography></Grid>
+                </Grid>
+            </Box>
 
-            <Accordion defaultExpanded sx={{mb:2, boxShadow: 'none', '&:before': {display: 'none'} }}>
-                 <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{backgroundColor: (vehicle.ultimaFechaDesinfeccion ? theme.palette.success.lighter : theme.palette.warning.lighter)+'33', borderRadius:1}}>
-                    <VerifiedUserIcon sx={{mr:1, color: vehicle.ultimaFechaDesinfeccion ? theme.palette.success.main : theme.palette.warning.main }} /> <Typography variant="h6" sx={{ color: vehicle.ultimaFechaDesinfeccion ? theme.palette.success.dark : theme.palette.warning.dark }}>Última Desinfección</Typography>
-                </AccordionSummary>
-                <AccordionDetails sx={{pt:1.5}}>
-                    <Typography variant="body1"><strong>Fecha:</strong> <span style={{ fontWeight: 'bold', color: vehicle.ultimaFechaDesinfeccion ? theme.palette.success.dark : theme.palette.warning.dark }}>{formatDate(vehicle.ultimaFechaDesinfeccion)}</span></Typography>
-                    <Typography variant="body1"><strong>Recibo (MSI):</strong> {vehicle.ultimoReciboPago || 'N/A'} {vehicle.ultimaUrlRecibo && <Button size="small" href={vehicle.ultimaUrlRecibo} target="_blank" rel="noopener noreferrer">(Ver Foto)</Button>}</Typography>
-                    <Typography variant="body1"><strong>Nº Transacción:</strong> {vehicle.ultimaTransaccionPago || 'N/A'} {vehicle.ultimaUrlTransaccion && <Button size="small" href={vehicle.ultimaUrlTransaccion} target="_blank" rel="noopener noreferrer">(Ver Foto)</Button>}</Typography>
-                    <Typography variant="body1"><strong>Monto Pagado:</strong> {vehicle.ultimoMontoPagado ? `$${parseFloat(vehicle.ultimoMontoPagado).toFixed(2)}` : 'N/A'}</Typography>
-                    <Typography variant="body1"><strong>Observaciones:</strong> {vehicle.ultimasObservaciones || 'N/A'}</Typography>
-                </AccordionDetails>
-            </Accordion>
+            <Box sx={{mb:3}}>
+                <Box sx={{display:'flex', alignItems:'center', mb:1}}>
+                    <VerifiedUserIcon sx={{mr:1, color: vehicle.ultimaFechaDesinfeccion ? theme.palette.success.main : theme.palette.warning.main}} />
+                    <Typography variant="h6" sx={{color: vehicle.ultimaFechaDesinfeccion ? theme.palette.success.dark : theme.palette.warning.dark}}>Última Desinfección</Typography>
+                </Box>
+                <Divider sx={{mb:1}} />
+                <Typography variant="body1"><strong>Fecha:</strong> <span style={{ fontWeight: 'bold', color: vehicle.ultimaFechaDesinfeccion ? theme.palette.success.dark : theme.palette.warning.dark }}>{formatDate(vehicle.ultimaFechaDesinfeccion)}</span></Typography>
+                <Typography variant="body1"><strong>Recibo (MSI):</strong> {vehicle.ultimoReciboPago || 'N/A'} {vehicle.ultimaUrlRecibo && <Button size="small" href={vehicle.ultimaUrlRecibo} target="_blank" rel="noopener noreferrer">(Ver Foto)</Button>}</Typography>
+                <Typography variant="body1"><strong>Nº Transacción:</strong> {vehicle.ultimaTransaccionPago || 'N/A'} {vehicle.ultimaUrlTransaccion && <Button size="small" href={vehicle.ultimaUrlTransaccion} target="_blank" rel="noopener noreferrer">(Ver Foto)</Button>}</Typography>
+                <Typography variant="body1"><strong>Monto Pagado:</strong> {vehicle.ultimoMontoPagado ? `$${parseFloat(vehicle.ultimoMontoPagado).toFixed(2)}` : 'N/A'}</Typography>
+                <Typography variant="body1"><strong>Observaciones:</strong> {vehicle.ultimasObservaciones || 'N/A'}</Typography>
+            </Box>
 
-            <Accordion sx={{boxShadow: 'none', '&:before': {display: 'none'} }}>
-                <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{backgroundColor: theme.palette.grey[100], borderRadius:1}}>
-                    <CalendarTodayIcon sx={{mr:1, color: 'action.active'}} /> <Typography variant="h6" color="text.secondary">Historial de Desinfecciones</Typography>
-                </AccordionSummary>
-                <AccordionDetails sx={{pt:1.5}}>
-                    {vehicle.historialDesinfecciones && vehicle.historialDesinfecciones.length > 0 ? (
-                        <List dense sx={{maxHeight: 200, overflow: 'auto', p:0}}>
-                            {vehicle.historialDesinfecciones.map((item, index) => (
-                                <ListItem key={index} divider sx={{py: 0.5}}>
-                                    <ListItemText
-                                        primary={`Fecha: ${formatDate(item.fecha)}`}
-                                        secondary={
-                                            <>
-                                            Recibo: {item.recibo} {item.urlRecibo && <Button size="small" sx={{ml:0.5, p:0.1}} href={item.urlRecibo} target="_blank">(F)</Button>} |
-                                            Trans.: {item.transaccion || 'N/A'} {item.urlTransaccion && <Button size="small" sx={{ml:0.5, p:0.1}} href={item.urlTransaccion} target="_blank">(F)</Button>} |
-                                            Monto: $${item.montoPagado ? parseFloat(item.montoPagado).toFixed(2) : 'N/A'} |
-                                            Obs: {item.observaciones || '-'}
-                                            </>
-                                        }
-                                    />
-                                </ListItem>
-                            ))}
-                        </List>
-                    ) : (
-                        <Typography color="text.secondary" sx={{fontStyle: 'italic'}}>No hay historial de desinfecciones registrado.</Typography>
-                    )}
-                </AccordionDetails>
-            </Accordion>
+
+            <Box>
+                <Box sx={{display:'flex', alignItems:'center', mb:1}}>
+                    <CalendarTodayIcon sx={{mr:1, color: 'action.active'}} />
+                    <Typography variant="h6" color="text.secondary">Historial de Desinfecciones</Typography>
+                </Box>
+                <Divider sx={{mb:1}} />
+                {vehicle.historialDesinfecciones && vehicle.historialDesinfecciones.length > 0 ? (
+                    <List dense sx={{maxHeight: 200, overflow: 'auto', p:0}}>
+                        {vehicle.historialDesinfecciones.map((item, index) => (
+                            <ListItem key={index} divider sx={{py: 0.5}}>
+                                <ListItemText
+                                    primary={`Fecha: ${formatDate(item.fecha)}`}
+                                    secondary={
+                                        <>
+                                        Recibo: {item.recibo} {item.urlRecibo && <Button size="small" sx={{ml:0.5, p:0.1}} href={item.urlRecibo} target="_blank">(F)</Button>} |
+                                        Trans.: {item.transaccion || 'N/A'}{item.urlTransaccion && <Button size="small" sx={{ml:0.5, p:0.1}} href={item.urlTransaccion} target="_blank">(F)</Button>} |
+                                        Monto: $${item.montoPagado ? parseFloat(item.montoPagado).toFixed(2) : 'N/A'} |
+                                        Obs: {item.observaciones || '-'}
+                                        </>
+                                    }
+                                />
+                            </ListItem>
+                        ))}
+                    </List>
+                ) : (
+                    <Typography color="text.secondary" sx={{fontStyle: 'italic'}}>No hay historial de desinfecciones registrado.</Typography>
+                )}
+            </Box>
             <Typography variant="caption" display="block" color="text.secondary" sx={{ mt: 3, textAlign: 'center' }}>
                 ID Credencial (Vehículo): {vehicle.id}
             </Typography>


### PR DESCRIPTION
## Summary
- refactor the DigitalCredential component
- replace accordions with cleaner sections for a credential-style look

## Testing
- `npm test -- --watchAll=false` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_684e0bc6c7d4832696d954d25236a7a2