### PR TITLE
Add logs section

### DIFF
--- a/src/components/pages/LogsPage.js
+++ b/src/components/pages/LogsPage.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { StyledPaper } from '../../theme';
+import { Typography, List, ListItem, ListItemText } from '@mui/material';
+
+const LogsPage = ({ logs }) => (
+    <StyledPaper>
+        <Typography variant="h5" component="h2" gutterBottom>Logs del Sistema</Typography>
+        {logs && logs.length > 0 ? (
+            <List>
+                {logs.map(log => {
+                    const date = log.timestamp && typeof log.timestamp.toDate === 'function'
+                        ? log.timestamp.toDate()
+                        : new Date(log.timestamp);
+                    return (
+                        <ListItem key={log.id} divider>
+                            <ListItemText
+                                primary={`${date.toLocaleString()} - ${log.action}`}
+                                secondary={log.details || ''}
+                            />
+                        </ListItem>
+                    );
+                })}
+            </List>
+        ) : (
+            <Typography color="text.secondary" sx={{ mt:2, fontStyle:'italic' }}>No hay logs para mostrar.</Typography>
+        )}
+    </StyledPaper>
+);
+
+export default LogsPage;

--- a/src/services/firestoreService.js
+++ b/src/services/firestoreService.js
@@ -8,6 +8,8 @@ import {
     deleteDoc,
     getDoc,
     getDocs,
+    addDoc,
+    orderBy,
     Timestamp,
     onSnapshot
 } from 'firebase/firestore';
@@ -287,6 +289,27 @@ export const fetchAdminUsers = (usersCollectionPath, callback) => {
     }, (error) => {
         console.error('User Fetch Error: ', error);
         callback({ error: 'Error al cargar usuarios.' });
+    });
+};
+
+export const addLogEntry = async (logsCollectionPath, userId, action, details) => {
+    const ref = collection(db, logsCollectionPath);
+    await addDoc(ref, {
+        userId,
+        action,
+        details,
+        timestamp: Timestamp.now()
+    });
+};
+
+export const fetchLogs = (logsCollectionPath, callback) => {
+    const q = query(collection(db, logsCollectionPath), orderBy('timestamp', 'desc'));
+    return onSnapshot(q, (snap) => {
+        const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+        callback({ data });
+    }, (error) => {
+        console.error('Logs Fetch Error: ', error);
+        callback({ error: 'Error al cargar logs.' });
     });
 };
 


### PR DESCRIPTION
## Summary
- create LogsPage component
- support logs via Firestore service and show logs page
- log actions when vehicles or disinfect events change
- add navigation link to logs

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685341414e3c83268fce970932a2d39f