### PR TITLE
Add filter to search vehicles without disinfection

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -115,6 +115,7 @@ function App() {
     const [filterTipoVehiculo, setFilterTipoVehiculo] = useState('');
     const [filterDesde, setFilterDesde] = useState('');
     const [filterHasta, setFilterHasta] = useState('');
+    const [filterSinDesinfeccion, setFilterSinDesinfeccion] = useState(false);
     const [searchResults, setSearchResults] = useState([]);
     const [allVehiclesForDashboard, setAllVehiclesForDashboard] = useState([]);
     const [loading, setLoading] = useState(false);
@@ -315,6 +316,9 @@ function App() {
                 return d <= to;
             });
         }
+        if (filterSinDesinfeccion) {
+            results = results.filter(v => !v.ultimaFechaDesinfeccion);
+        }
         return results;
     };
 
@@ -340,7 +344,7 @@ function App() {
         if (currentPage === 'admin') {
             setSearchResults(applyFilters());
         }
-    }, [allVehiclesForDashboard, currentPage, searchTerm, filterTipoVehiculo, filterDesde, filterHasta]);
+    }, [allVehiclesForDashboard, currentPage, searchTerm, filterTipoVehiculo, filterDesde, filterHasta, filterSinDesinfeccion]);
 
     // showSnackbar and handleCloseSnackbar are obtained from useSnackbar hook
 
@@ -580,6 +584,8 @@ function App() {
                             setFilterDesde={setFilterDesde}
                             filterHasta={filterHasta}
                             setFilterHasta={setFilterHasta}
+                            filterSinDesinfeccion={filterSinDesinfeccion}
+                            setFilterSinDesinfeccion={setFilterSinDesinfeccion}
                             allVehicles={allVehiclesForDashboard}
                             adminUsers={adminUsers}
                             onAddUser={handleAddAdminUser}

--- a/src/components/pages/AdminPage.js
+++ b/src/components/pages/AdminPage.js
@@ -2,7 +2,8 @@ import React, { useState, useEffect } from 'react';
 import {
     TextField, Button, Box, Typography, IconButton, List, ListItem, ListItemText,
     Accordion, AccordionSummary, AccordionDetails, InputAdornment,
-    FormControl, InputLabel, Select, MenuItem
+    FormControl, InputLabel, Select, MenuItem,
+    FormControlLabel, Checkbox
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import SearchIcon from '@mui/icons-material/Search';
@@ -35,6 +36,8 @@ const AdminPage = ({
     setFilterDesde,
     filterHasta,
     setFilterHasta,
+    filterSinDesinfeccion,
+    setFilterSinDesinfeccion,
     allVehicles,
     adminUsers,
     onAddUser,
@@ -115,6 +118,10 @@ const AdminPage = ({
                 </FormControl>
                 <TextField type="date" label="Desde" value={filterDesde} onChange={(e) => setFilterDesde(e.target.value)} InputLabelProps={{ shrink: true }} sx={{ minWidth: 150 }}/>
                 <TextField type="date" label="Hasta" value={filterHasta} onChange={(e) => setFilterHasta(e.target.value)} InputLabelProps={{ shrink: true }} sx={{ minWidth: 150 }}/>
+                <FormControlLabel
+                    control={<Checkbox checked={filterSinDesinfeccion} onChange={(e) => setFilterSinDesinfeccion(e.target.checked)} />}
+                    label="Sin desinfección"
+                />
                 <Button variant="contained" onClick={handleSearch} startIcon={<SearchIcon />}>Buscar</Button>
             </Box>
             {searchResults.length > 0 ? (


### PR DESCRIPTION
## Summary
- extend search filters with `filterSinDesinfeccion`
- expose new checkbox in AdminPage to show vehicles without any disinfection records

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685345dbdd848326ab107e151b79081b