### PR TITLE
feat: ensure credential uses most recent disinfection

### DIFF
--- a/src/components/pages/VehicleDetailPage.js
+++ b/src/components/pages/VehicleDetailPage.js
@@ -17,6 +17,7 @@ import EditIcon from '@mui/icons-material/Edit';
 // import { styled, useTheme } from '@mui/material/styles'; // useTheme is used, styled for StyledPaper is imported
 import { useTheme } from '@mui/material/styles';
 import { StyledPaper } from '../../theme'; // Import StyledPaper, theme is available via useTheme
+import { getLatestDisinfectionInfo } from '../../utils/disinfectionUtils';
 import { Timestamp } from 'firebase/firestore';
 import { callGeminiAPI } from '../../services/geminiService';
 
@@ -62,6 +63,16 @@ const VehicleDetailPage = ({
             if (onAutoShowHandled) onAutoShowHandled();
         }
     }, [autoShowAddForm, onAutoShowHandled]);
+
+    const {
+        ultimaFechaDesinfeccion,
+        ultimoReciboPago,
+        ultimaUrlRecibo,
+        ultimaTransaccionPago,
+        ultimaUrlTransaccion,
+        ultimoMontoPagado,
+        ultimasObservaciones,
+    } = useMemo(() => getLatestDisinfectionInfo(vehicle), [vehicle]);
 
     const montoEstimado = useMemo(() => {
         const m3 = parseFloat(vehicle.metrosCubicos);
@@ -196,11 +207,11 @@ const VehicleDetailPage = ({
                 <Typography><strong>Propietario:</strong> {vehicle.propietarioNombre}</Typography>
                 <Typography><strong>Nº Vehículo Municipal:</strong> {vehicle.numeroVehiculoMunicipal || 'N/A'}</Typography>
                 <Divider sx={{my:1}}/>
-                <Typography><strong>Última Desinfección:</strong> <span style={{ fontWeight: 'bold', color: vehicle.ultimaFechaDesinfeccion ? theme.palette.success.dark : theme.palette.warning.dark }}>{formatDate(vehicle.ultimaFechaDesinfeccion)}</span></Typography>
-                <Typography><strong>Último Recibo:</strong> {vehicle.ultimoReciboPago || 'N/A'} {vehicle.ultimaUrlRecibo && <Button size="small" href={vehicle.ultimaUrlRecibo} target="_blank" rel="noopener noreferrer">Ver Foto</Button>}</Typography>
-                <Typography><strong>Última Transacción:</strong> {vehicle.ultimaTransaccionPago || 'N/A'} {vehicle.ultimaUrlTransaccion && <Button size="small" href={vehicle.ultimaUrlTransaccion} target="_blank" rel="noopener noreferrer">Ver Foto</Button>}</Typography>
-                <Typography><strong>Último Monto Pagado:</strong> $ {vehicle.ultimoMontoPagado ? parseFloat(vehicle.ultimoMontoPagado).toFixed(2) : 'N/A'}</Typography>
-                <Typography><strong>Últimas Observaciones:</strong> {vehicle.ultimasObservaciones || 'N/A'}</Typography>
+                <Typography><strong>Última Desinfección:</strong> <span style={{ fontWeight: 'bold', color: ultimaFechaDesinfeccion ? theme.palette.success.dark : theme.palette.warning.dark }}>{formatDate(ultimaFechaDesinfeccion)}</span></Typography>
+                <Typography><strong>Último Recibo:</strong> {ultimoReciboPago || 'N/A'} {ultimaUrlRecibo && <Button size="small" href={ultimaUrlRecibo} target="_blank" rel="noopener noreferrer">Ver Foto</Button>}</Typography>
+                <Typography><strong>Última Transacción:</strong> {ultimaTransaccionPago || 'N/A'} {ultimaUrlTransaccion && <Button size="small" href={ultimaUrlTransaccion} target="_blank" rel="noopener noreferrer">Ver Foto</Button>}</Typography>
+                <Typography><strong>Último Monto Pagado:</strong> $ {ultimoMontoPagado ? parseFloat(ultimoMontoPagado).toFixed(2) : 'N/A'}</Typography>
+                <Typography><strong>Últimas Observaciones:</strong> {ultimasObservaciones || 'N/A'}</Typography>
             </Paper>
 
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, my: 3 }}>

--- a/src/utils/disinfectionUtils.js
+++ b/src/utils/disinfectionUtils.js
@@ -1,0 +1,39 @@
+import { DIAS_VIGENCIA_TIPO } from '../theme';
+
+export const getLatestDisinfectionInfo = (vehicle = {}) => {
+  const historial = vehicle.historialDesinfecciones || [];
+  if (!historial.length) {
+    return {
+      ultimaFechaDesinfeccion: null,
+      fechaVencimiento: null,
+      ultimoReciboPago: null,
+      ultimaUrlRecibo: null,
+      ultimaTransaccionPago: null,
+      ultimaUrlTransaccion: null,
+      ultimoMontoPagado: null,
+      ultimasObservaciones: null,
+    };
+  }
+  const sorted = [...historial].sort((a, b) => {
+    const dateA = a.fecha?.toDate ? a.fecha.toDate() : new Date(a.fecha);
+    const dateB = b.fecha?.toDate ? b.fecha.toDate() : new Date(b.fecha);
+    return dateB - dateA;
+  });
+  const latest = sorted[0];
+  const ultimaDate = latest.fecha?.toDate ? latest.fecha.toDate() : new Date(latest.fecha);
+  const diasVigencia = DIAS_VIGENCIA_TIPO[vehicle.tipoVehiculo] || 30;
+  const fechaVencimiento = ultimaDate
+    ? new Date(ultimaDate.getTime() + diasVigencia * 24 * 60 * 60 * 1000)
+    : null;
+
+  return {
+    ultimaFechaDesinfeccion: ultimaDate,
+    fechaVencimiento,
+    ultimoReciboPago: latest.recibo || null,
+    ultimaUrlRecibo: latest.urlRecibo || null,
+    ultimaTransaccionPago: latest.transaccion || null,
+    ultimaUrlTransaccion: latest.urlTransaccion || null,
+    ultimoMontoPagado: latest.montoPagado || null,
+    ultimasObservaciones: latest.observaciones || null,
+  };
+};


### PR DESCRIPTION
## Summary
- add utility to compute latest disinfection details and expiration from vehicle history
- update digital credential and vehicle detail views to use most recent disinfection info and expiration

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689334c2cf4c83268bba5ba179fa477e