### PR TITLE
Add thermal printer receipt button

### DIFF
--- a/public/recibo-termico.html
+++ b/public/recibo-termico.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Recibo para Impresora Térmica 58mm</title>
+    <script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.all.min.js"></script>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&display=swap');
+
+        /* --- Estilos Generales --- */
+        body {
+            font-family: 'Inconsolata', monospace;
+            background-color: #f0f2f5;
+            color: #333;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        /* --- Contenedor del Recibo --- */
+        .receipt-container {
+            display: flex;
+            width: 380px; /* Ancho para visualización en pantalla */
+            background-color: #fff;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+            border-radius: 8px;
+            overflow: hidden;
+        }
+
+        /* --- Contenido Principal del Recibo --- */
+        .receipt-content {
+            padding: 15px;
+            width: 100%;
+            box-sizing: border-box;
+        }
+
+        /* --- Contenedor del Código de Barras --- */
+        .barcode-container {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 10px;
+            background-color: #f8f9fa;
+            min-width: 60px; /* Ancho mínimo para el contenedor */
+        }
+
+        .barcode-vertical {
+            transform: rotate(-90deg);
+            transform-origin: center;
+        }
+
+        /* --- Estilos de Texto --- */
+        .header, .footer {
+            text-align: center;
+        }
+
+        .header h1 {
+            margin: 0;
+            font-size: 16px;
+            font-weight: 700;
+        }
+
+        .header p {
+            margin: 2px 0;
+            font-size: 12px;
+        }
+        
+        .item-list, .info-list {
+            margin: 15px 0;
+            font-size: 12px;
+            list-style: none;
+            padding: 0;
+        }
+
+        .info-list li, .item-list li {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 5px;
+            line-height: 1.4;
+        }
+
+        .item-list .total {
+            font-weight: 700;
+            border-top: 1px dashed #999;
+            padding-top: 5px;
+            margin-top: 10px;
+        }
+        
+        .label {
+            font-weight: bold;
+            margin-right: 5px;
+        }
+
+        .value {
+            text-align: right;
+        }
+        
+        hr {
+            border: none;
+            border-top: 1px dashed #999;
+            margin: 15px 0;
+        }
+
+        .footer p {
+            font-size: 10px;
+            margin: 5px 0;
+        }
+
+        /* --- Estilos para la Impresión --- */
+        @media print {
+            body {
+                background-color: #fff;
+                padding: 0;
+            }
+
+            .print-button-container {
+                display: none;
+            }
+
+            .receipt-container {
+                /* Ancho para impresora térmica de 58mm (aprox. 2.28 pulgadas) */
+                /* Se usa un poco menos para márgenes de impresión */
+                width: 56mm; 
+                box-shadow: none;
+                border: none;
+                margin: 0;
+                padding: 0;
+            }
+            
+            .receipt-content {
+                padding: 1mm;
+            }
+
+            .barcode-container {
+                padding: 1mm;
+                min-width: 15mm;
+            }
+
+            /* Ajustar fuentes para la impresión */
+            .header h1 { font-size: 10pt; }
+            .header p { font-size: 7pt; }
+            .info-list, .item-list { font-size: 7pt; }
+            .footer p { font-size: 6pt; }
+        }
+
+        /* --- Botón de Impresión --- */
+        .print-button-container {
+            margin-top: 20px;
+            text-align: center;
+        }
+
+        .print-button {
+            background-color: #007bff;
+            color: white;
+            padding: 12px 25px;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 16px;
+            transition: background-color 0.3s;
+        }
+
+        .print-button:hover {
+            background-color: #0056b3;
+        }
+    </style>
+</head>
+<body>
+
+    <div class="receipt-container" id="receipt">
+        <!-- Contenido principal del recibo -->
+        <div class="receipt-content">
+            <div class="header">
+                <h1>MUNICIPALIDAD DE SAN ISIDRO</h1>
+                <p>Recibo Oficial</p>
+            </div>
+
+            <hr>
+
+            <ul class="info-list">
+                <li><span class="label">Recibo:</span> <span class="value" id="receipt-id">5-2522978</span></li>
+                <li><span class="label">Titular:</span> <span class="value" id="holder-name">Damian Holasek</span></li>
+                <li><span class="label">DNI/CUIT:</span> <span class="value" id="holder-id">38168225</span></li>
+                 <li><span class="label">Fecha:</span> <span class="value" id="receipt-date">14/08/2025</span></li>
+            </ul>
+
+            <hr>
+
+            <ul class="item-list">
+                <li>
+                    <span>Tasa: 2105 - OTROS SERV. SANITARIOS</span>
+                    <span class="value">$ 1,00</span>
+                </li>
+                <li>
+                    <span>Periodo: 2025 / Cuota: 0000</span>
+                    <span class="value"></span>
+                </li>
+                <li class="total">
+                    <span>TOTAL A PAGAR</span>
+                    <span class="value">$ 1,00</span>
+                </li>
+            </ul>
+
+            <hr>
+
+            <div class="footer">
+                <p><span class="label">Vencimiento:</span> 15/08/2025</p>
+                <p><strong>Observaciones:</strong></p>
+                <p>DESINFECCION MES DE ABRIL 2025 DOMINIO AA115AP</p>
+                <p>UNICAMENTE PARA SER ABONADO EN TESORERIA MUNICIPAL</p>
+            </div>
+        </div>
+        
+        <!-- Contenedor del código de barras vertical -->
+        <div class="barcode-container">
+            <svg id="barcode" class="barcode-vertical"></svg>
+        </div>
+    </div>
+
+    <div class="print-button-container">
+        <button class="print-button" onclick="window.print()">Imprimir Recibo</button>
+    </div>
+
+    <script>
+        // --- Generación del Código de Barras ---
+        document.addEventListener('DOMContentLoaded', function () {
+            // Número de código de barras del recibo de ejemplo
+            const barcodeValue = "16500000001002270000000000000500252297825089";
+            
+            // Generar el código de barras usando JsBarcode
+            JsBarcode("#barcode", barcodeValue, {
+                format: "CODE128", // Formato común y versátil
+                width: 1.5,       // Ancho de las barras
+                height: 200,      // Altura del código (será el ancho al rotarlo)
+                displayValue: false // No mostrar el número debajo del código
+            });
+        });
+    </script>
+
+</body>
+</html>

--- a/src/components/pages/VehicleDetailPage.js
+++ b/src/components/pages/VehicleDetailPage.js
@@ -14,6 +14,7 @@ import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 // import { styled, useTheme } from '@mui/material/styles'; // useTheme is used, styled for StyledPaper is imported
 import { useTheme } from '@mui/material/styles';
 import { StyledPaper } from '../../theme'; // Import StyledPaper, theme is available via useTheme
@@ -223,6 +224,15 @@ const VehicleDetailPage = ({
                         </Button>
                         <Button variant="outlined" color="primary" startIcon={<PaymentIcon />} onClick={onOpenPaymentPage}>
                             Generar Boleta de Pago
+                        </Button>
+                        <Button
+                            variant="outlined"
+                            color="primary"
+                            startIcon={<ReceiptLongIcon />}
+                            href="/recibo-termico.html"
+                            target="_blank"
+                        >
+                            Generar recibo para impresora térmica
                         </Button>
                     </>
                 )}


### PR DESCRIPTION
## Summary
- add button to generate receipt for thermal printers
- create standalone thermal receipt HTML page

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689decb310a48326ad1e6bac8971c8fe