### PR TITLE
Allow PDF uploads for receipts and edit disinfection records

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -454,11 +454,11 @@ function App() {
         setLoading(false);
     };
 
-    const handleUpdateDisinfection = async (vehicleId, fechaRegistroMillis, data) => {
+    const handleUpdateDisinfection = async (vehicleId, fechaRegistroMillis, data, reciboFile) => {
         if (!currentUser) { showSnackbar("Debe estar autenticado.", "error"); return; }
         setLoading(true);
         try {
-            const updated = await updateDisinfectionService(vehiclesCollectionPath, vehicleId, fechaRegistroMillis, data);
+            const updated = await updateDisinfectionService(vehiclesCollectionPath, vehicleId, fechaRegistroMillis, data, reciboFile, appId);
             setSelectedVehicleForApp(updated);
             showSnackbar("Registro actualizado.", "success");
             await addLogEntryService(logsCollectionPath, currentUser.uid, 'Edición desinfección', `Vehículo ${vehicleId}`);

--- a/src/components/pages/VehicleDetailPage.js
+++ b/src/components/pages/VehicleDetailPage.js
@@ -55,9 +55,11 @@ const VehicleDetailPage = ({
     const [disinfectionDataToSubmit, setDisinfectionDataToSubmit] = useState(null);
     const [openSummaryDialog, setOpenSummaryDialog] = useState(false);
     const [historySummary, setHistorySummary] = useState('');
+    const [editReciboFile, setEditReciboFile] = useState(null);
     const [editRecord, setEditRecord] = useState(null);
     const [openDeleteDialog, setOpenDeleteDialog] = useState(null);
     const [openDeleteVehicleDialog, setOpenDeleteVehicleDialog] = useState(false);
+    const [savingEdit, setSavingEdit] = useState(false);
 
     useEffect(() => {
         if (autoShowAddForm) {
@@ -278,8 +280,8 @@ const VehicleDetailPage = ({
                         </Grid>
                         <Grid item xs={12} sm={4}>
                             <Button variant="outlined" component="label" fullWidth startIcon={<CloudUploadIcon />} sx={{mt: {xs:0, sm:1}}}>
-                                Foto Recibo
-                                <input type="file" hidden accept="image/*" capture="environment" onChange={(e) => handleFileChange(e, setReciboFile)} />
+                                Recibo (Foto/PDF)
+                                <input type="file" hidden accept="image/*,application/pdf" onChange={(e) => handleFileChange(e, setReciboFile)} />
                             </Button>
                             {reciboFile && <Typography variant="caption" display="block" sx={{mt:0.5, textAlign:'center'}}>{reciboFile.name}</Typography>}
                         </Grid>
@@ -291,8 +293,8 @@ const VehicleDetailPage = ({
                         </Grid>
                         <Grid item xs={12} sm={4}>
                              <Button variant="outlined" component="label" fullWidth startIcon={<CloudUploadIcon />} sx={{mt: {xs:0, sm:1}}}>
-                                Foto Trans.
-                                <input type="file" hidden accept="image/*" capture="environment" onChange={(e) => handleFileChange(e, setTransaccionFile)} />
+                                Comprobante (Foto/PDF)
+                                <input type="file" hidden accept="image/*,application/pdf" onChange={(e) => handleFileChange(e, setTransaccionFile)} />
                             </Button>
                             {transaccionFile && <Typography variant="caption" display="block" sx={{mt:0.5, textAlign:'center'}}>{transaccionFile.name}</Typography>}
                         </Grid>
@@ -399,13 +401,45 @@ const VehicleDetailPage = ({
                                 InputLabelProps={{ shrink: true }}
                             />
                             <TextField label="Recibo" value={editRecord.recibo} onChange={(e)=>setEditRecord({...editRecord,recibo:e.target.value})} fullWidth margin="dense" />
+                            <Button variant="outlined" component="label" startIcon={<CloudUploadIcon />} sx={{mt:1}}>
+                                Subir Boleta (PDF/Imagen)
+                                <input type="file" hidden accept="image/*,application/pdf" onChange={(e) => handleFileChange(e, setEditReciboFile)} />
+                            </Button>
+                            {editReciboFile && <Typography variant="caption" display="block" sx={{mt:0.5}}>{editReciboFile.name}</Typography>}
                             <TextField label="Transacción" value={editRecord.transaccion || ''} onChange={(e)=>setEditRecord({...editRecord,transaccion:e.target.value})} fullWidth margin="dense" />
                             <TextField label="Monto Pagado" type="number" value={editRecord.montoPagado} onChange={(e)=>setEditRecord({...editRecord,montoPagado:e.target.value})} fullWidth margin="dense" />
                             <TextField label="Observaciones" value={editRecord.observaciones || ''} onChange={(e)=>setEditRecord({...editRecord,observaciones:e.target.value})} fullWidth multiline rows={3} margin="dense" />
                         </DialogContent>
                         <DialogActions>
-                            <Button onClick={() => setEditRecord(null)}>Cancelar</Button>
-                            <Button onClick={() => { onUpdateDisinfection(vehicle.id, editRecord.fechaRegistro.toMillis(), { fecha: editRecord.fecha instanceof Date ? Timestamp.fromDate(editRecord.fecha) : editRecord.fecha, recibo: editRecord.recibo, transaccion: editRecord.transaccion || '', montoPagado: parseFloat(editRecord.montoPagado) || 0, observaciones: editRecord.observaciones || '' }); setEditRecord(null); }} color="primary">Guardar</Button>
+                            <Button onClick={() => { setEditRecord(null); setEditReciboFile(null); }}>Cancelar</Button>
+                            <Button
+                                onClick={async () => {
+                                    setSavingEdit(true);
+                                    try {
+                                        await onUpdateDisinfection(
+                                            vehicle.id,
+                                            editRecord.fechaRegistro.toMillis(),
+                                            {
+                                                fecha: editRecord.fecha instanceof Date ? Timestamp.fromDate(editRecord.fecha) : editRecord.fecha,
+                                                recibo: editRecord.recibo,
+                                                transaccion: editRecord.transaccion || '',
+                                                montoPagado: parseFloat(editRecord.montoPagado) || 0,
+                                                observaciones: editRecord.observaciones || ''
+                                            },
+                                            editReciboFile
+                                        );
+                                        setEditRecord(null);
+                                        setEditReciboFile(null);
+                                    } catch (e) {
+                                        showSnackbar(e.message || 'Error al actualizar registro.', 'error');
+                                    }
+                                    setSavingEdit(false);
+                                }}
+                                color="primary"
+                                disabled={savingEdit}
+                            >
+                                Guardar
+                            </Button>
                         </DialogActions>
                     </>
                 )}

--- a/src/services/firestoreService.js
+++ b/src/services/firestoreService.js
@@ -197,7 +197,7 @@ export const handleDeleteVehicle = async (vehiclesCollectionPath, vehicleId) => 
     await deleteDoc(doc(db, vehiclesCollectionPath, vehicleId));
 };
 
-export const handleUpdateDisinfection = async (vehiclesCollectionPath, vehicleId, fechaRegistroMillis, updatedFields) => {
+export const handleUpdateDisinfection = async (vehiclesCollectionPath, vehicleId, fechaRegistroMillis, updatedFields, reciboFile, appId) => {
     const vehicleRef = doc(db, vehiclesCollectionPath, vehicleId);
     const snap = await getDoc(vehicleRef);
     if (!snap.exists()) throw new Error('Vehículo no encontrado.');
@@ -220,7 +220,15 @@ export const handleUpdateDisinfection = async (vehiclesCollectionPath, vehicleId
             throw new Error('Ya existe una desinfección registrada para este mes.');
         }
     }
-    historial[index] = { ...historial[index], ...updatedFields };
+    const updatedRecord = { ...historial[index], ...updatedFields };
+    if (reciboFile) {
+        const timestamp = Date.now();
+        const reciboPath = `recibos/${appId}/${vehicleId}/${timestamp}_${reciboFile.name}`;
+        const urlRecibo = await uploadFileToStorage(reciboFile, reciboPath);
+        updatedRecord.urlRecibo = urlRecibo;
+        updatedRecord.nombreArchivoRecibo = reciboFile.name;
+    }
+    historial[index] = updatedRecord;
     const sorted = [...historial].sort((a,b) => b.fecha.toMillis() - a.fecha.toMillis());
     const ultima = sorted[0] || {};
     const diasVigencia = DIAS_VIGENCIA_TIPO[vehicle.tipoVehiculo] || 30;


### PR DESCRIPTION
## Summary
- allow uploading receipts and payment proofs as PDF or images
- enable uploading a receipt PDF when editing a disinfection record
- upload updated PDFs to storage when saving edited records
- avoid hangs when adding receipt PDFs to existing disinfections

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b848deb520832683dd619196e234fd